### PR TITLE
Add filtering on lines and direction

### DIFF
--- a/custom_components/hasl3/sensor.py
+++ b/custom_components/hasl3/sensor.py
@@ -472,8 +472,8 @@ class HASLDepartureSensor(HASLDevice):
 
         try:
             departures = self._sensordata["data"]
-            direction_filtered = list(filter(self.filter_direction, departures))
-            lines_filtered = list(filter(self.filter_lines, direction_filtered))
+            dirs_filtered = list(filter(self.filter_direction, departures))
+            lines_filtered = list(filter(self.filter_lines, dirs_filtered))
 
             val['attribution'] = self._sensordata["attribution"]
             val['departures'] = lines_filtered

--- a/custom_components/hasl3/sensor.py
+++ b/custom_components/hasl3/sensor.py
@@ -470,11 +470,14 @@ class HASLDepartureSensor(HASLDevice):
         val['scan_interval'] = self._scan_interval
         val['refresh_enabled'] = self._worker.checksensorstate(self._enabled_sensor,STATE_ON)
 
-        try:
-            departures = self._sensordata["data"]
-            dirs_filtered = list(filter(self.filter_direction, departures))
-            lines_filtered = list(filter(self.filter_lines, dirs_filtered))
+        if val['api_result'] != "Ok":
+            return val
 
+        departures = self._sensordata["data"]
+        direction_filtered = list(filter(self.filter_direction, departures))
+        lines_filtered = list(filter(self.filter_lines, direction_filtered))
+
+        try:
             val['attribution'] = self._sensordata["attribution"]
             val['departures'] = lines_filtered
             val['deviations'] = self._sensordata["deviations"]

--- a/custom_components/hasl3/sensor.py
+++ b/custom_components/hasl3/sensor.py
@@ -410,6 +410,16 @@ class HASLDepartureSensor(HASLDevice):
                     return departure
         return None        
 
+    def filter_direction(self, departure):
+        if self._direction == 0:
+            return True
+        return departure["direction"] == self._direction
+
+    def filter_lines(self, departure):
+        if self._lines == []:
+            return True
+        return departure["line"] in self._lines
+
     @property
     def icon(self):
         """Return the icon of the sensor."""
@@ -461,8 +471,12 @@ class HASLDepartureSensor(HASLDevice):
         val['refresh_enabled'] = self._worker.checksensorstate(self._enabled_sensor,STATE_ON)
 
         try:
+            departures = self._sensordata["data"]
+            direction_filtered = list(filter(self.filter_direction, departures))
+            lines_filtered = list(filter(self.filter_lines, direction_filtered))
+
             val['attribution'] = self._sensordata["attribution"]
-            val['departures'] = self._sensordata["data"]
+            val['departures'] = lines_filtered
             val['deviations'] = self._sensordata["deviations"]
             val['last_refresh'] = self._sensordata["last_updated"]
             val['next_departure_minutes'] = expected_minutes


### PR DESCRIPTION
Closes #12 .

This PR implements the filtering on both lines and departures. It could be done more efficiently by first checking **if** the filtering should be done and then filter. However, it shouldn't be a problem since there's not all too much data to go through.