### PR TITLE
Dev to main 3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.5] (2022-03-17)
+
+### Fixes
+- Fixes [hasl-sensor/integration#36](https://github.com/hasl-sensor/integration/issues/36) introduced in 3.0.3
+- Fixes [hasl-sensor/integration#35](https://github.com/hasl-sensor/integration/issues/35) anoying log message due to stupidity
+
+### Changes
+- Sensor will now show unavailable until sensor data is initiated
+- Configuration now stored in data and not options inside of configuration object
+- Implemented separate configuration schema versioning (restarting with schema version 2. Everyting earlier is to be treated as version 1)
+- Now configures integration in one step when adding new integration
+- Harmonizing version settings between slapi and core as theese will never differ anymore
+
 ## [3.0.4] (2022-03-07)
 
 ### Fixes
@@ -341,6 +354,8 @@ Forked from 2.2.3 but changes from later versions are implemented as needed.
 - This is a great day indeed.
 
 [keep-a-changelog]: http://keepachangelog.com/en/1.0.0/
+[3.0.5]: https://github.com/hasl-sensor/integration/compare/3.0.4...3.0.5
+[3.0.4]: https://github.com/hasl-sensor/integration/compare/3.0.3...3.0.4
 [3.0.3]: https://github.com/hasl-sensor/integration/compare/3.0.2...3.0.3
 [3.0.2]: https://github.com/hasl-sensor/integration/compare/3.0.1...3.0.2
 [3.0.1]: https://github.com/hasl-sensor/integration/compare/3.0.0...3.0.1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![maintained](https://img.shields.io/maintenance/yes/2022.svg)
 [![hacs_badge](https://img.shields.io/badge/hacs-default-green.svg)](https://github.com/custom-components/hacs)
 [![ha_version](https://img.shields.io/badge/home%20assistant-2021.12%2B-green.svg)](https://www.home-assistant.io)
-![version](https://img.shields.io/badge/version-3.0.4-green.svg)
+![version](https://img.shields.io/badge/version-3.0.5-green.svg)
 ![stability-alpha](https://img.shields.io/badge/stability-stable-green.svg)
 [![maintainer](https://img.shields.io/badge/maintainer-dsorlov-blue.svg)](https://github.com/DSorlov)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/custom_components/hasl3/__init__.py
+++ b/custom_components/hasl3/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import device_registry as dr
 from .const import (
     DOMAIN,
     HASL_VERSION,
+    SCHEMA_VERSION,
     DEVICE_NAME,
     DEVICE_MANUFACTURER,
     DEVICE_MODEL,
@@ -200,12 +201,21 @@ async def async_setup(hass, config):
 async def async_migrate_entry(hass, config_entry: ConfigEntry):
     logger.debug("[migrate_entry] Entered")
 
-    logger.debug("[migrate_entry] Nothing to do from version %s to version %s", config_entry.version, HASL_VERSION)
+    logger.debug("[migrate_entry] Migrating configuration from schema version %s to version %s", config_entry.version, SCHEMA_VERSION)
 
-    logger.debug("[migrate_entry] Completed")
+    data = {**config_entry.data}   
+    for option in config_entry.options:
+        logger.debug(f"[migrate_entry] set {option} = {config_entry.options[option]}")
+        data[option]=config_entry.options[option]
+
+    try:
+        hass.config_entries.async_update_entry(config_entry, data=data)
+        logger.debug("[migrate_entry] Completed")
+    except Exception as e:
+        logger.error(f"[migrate_entry] Failed: {str(e)}")
+        return False
 
     return True
-
 
 async def reload_entry(hass, entry):
     """Reload HASL."""

--- a/custom_components/hasl3/binary_sensor.py
+++ b/custom_components/hasl3/binary_sensor.py
@@ -41,7 +41,7 @@ async def setup_hasl_sensor(hass, config):
 
     logger.debug("[setup_binary_sensor] Processing sensors")
     if config.data[CONF_INTEGRATION_TYPE] == SENSOR_STATUS:
-        if not config.options[CONF_ANALOG_SENSORS]:
+        if not CONF_ANALOG_SENSORS in config.options:
             if CONF_TL2_KEY in config.options:
                 await hass.data[DOMAIN]["worker"].assert_tl2(config.options[CONF_TL2_KEY])
                 for sensortype in CONF_TRANSPORT_MODE_LIST:

--- a/custom_components/hasl3/binary_sensor.py
+++ b/custom_components/hasl3/binary_sensor.py
@@ -41,11 +41,11 @@ async def setup_hasl_sensor(hass, config):
 
     logger.debug("[setup_binary_sensor] Processing sensors")
     if config.data[CONF_INTEGRATION_TYPE] == SENSOR_STATUS:
-        if not CONF_ANALOG_SENSORS in config.options:
-            if CONF_TL2_KEY in config.options:
-                await hass.data[DOMAIN]["worker"].assert_tl2(config.options[CONF_TL2_KEY])
+        if not CONF_ANALOG_SENSORS in config.data:
+            if CONF_TL2_KEY in config.data:
+                await hass.data[DOMAIN]["worker"].assert_tl2(config.data[CONF_TL2_KEY])
                 for sensortype in CONF_TRANSPORT_MODE_LIST:
-                    if sensortype in config.options and config.options[sensortype]:
+                    if sensortype in config.data and config.data[sensortype]:
                         logger.debug("[setup_binary_sensor] Setting up binary problem sensor..")
                         try:
                             sensors.append(HASLTrafficProblemSensor(hass, config, sensortype))
@@ -86,10 +86,10 @@ class HASLTrafficProblemSensor(HASLDevice):
         self._hass = hass
         self._config = config
         self._sensortype = sensortype
-        self._enabled_sensor = config.options[CONF_SENSOR]
+        self._enabled_sensor = config.data[CONF_SENSOR]
         self._name = f"SL {self._sensortype.capitalize()} Problem Sensor ({self._config.title})"
         self._sensordata = []
-        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -97,9 +97,9 @@ class HASLTrafficProblemSensor(HASLDevice):
 
         logger.debug("[async_update] Entered")
         logger.debug(f"[async_update] Processing {self._name}")
-        if self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]["api_lastrun"]:
+        if self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
+                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_tl2()
                         logger.debug("[async_update] Update processed")
@@ -108,7 +108,7 @@ class HASLTrafficProblemSensor(HASLDevice):
                 else:
                     logger.debug("[async_update] Not due for update, skipping")
 
-        self._sensordata = self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]
+        self._sensordata = self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]
         logger.debug("[async_update] Completed")
 
     @property
@@ -169,6 +169,11 @@ class HASLTrafficProblemSensor(HASLDevice):
     def scan_interval(self):
         """Return the unique id."""
         return self._scan_interval
+
+    @property
+    def available(self):
+        """Return true if value is valid."""
+        return self._sensordata != []        
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/hasl3/const.py
+++ b/custom_components/hasl3/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import (
     STATE_OFF
 )
 
-HASL_VERSION = "3.0.2"
+HASL_VERSION = "3.0.5"
 SCHEMA_VERSION = "2"
 DOMAIN = "hasl3"
 NAME = "SL Integration (HASL)"

--- a/custom_components/hasl3/const.py
+++ b/custom_components/hasl3/const.py
@@ -6,7 +6,8 @@ from homeassistant.const import (
     STATE_OFF
 )
 
-HASL_VERSION = "3.0.5"
+HASL_VERSION = "3.0.2"
+SCHEMA_VERSION = "2"
 DOMAIN = "hasl3"
 NAME = "SL Integration (HASL)"
 

--- a/custom_components/hasl3/const.py
+++ b/custom_components/hasl3/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import (
     STATE_OFF
 )
 
-HASL_VERSION = "3.0.4"
+HASL_VERSION = "3.0.5"
 DOMAIN = "hasl3"
 NAME = "SL Integration (HASL)"
 

--- a/custom_components/hasl3/manifest.json
+++ b/custom_components/hasl3/manifest.json
@@ -9,7 +9,7 @@
   "dependencies": [],
   "after_dependencies": [],
   "config_flow": true,
-  "version": "3.0.4",
+  "version": "3.0.5",
   "iot_class": "cloud_polling",
   "quality_scale": "silver",
   "requirements": [

--- a/custom_components/hasl3/sensor.py
+++ b/custom_components/hasl3/sensor.py
@@ -72,9 +72,9 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up RI4 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_STANDARD:
-            if CONF_RI4_KEY in config.options and CONF_SITE_ID in config.options:
-                await worker.assert_ri4(config.options[CONF_RI4_KEY], config.options[CONF_SITE_ID])
-                sensors.append(HASLDepartureSensor(hass, config, config.options[CONF_SITE_ID]))
+            if CONF_RI4_KEY in config.data and CONF_SITE_ID in config.data:
+                await worker.assert_ri4(config.data[CONF_RI4_KEY], config.data[CONF_SITE_ID])
+                sensors.append(HASLDepartureSensor(hass, config, config.data[CONF_SITE_ID]))
             logger.debug("[setup_hasl_sensor] Force proccessing RI4 sensors")
             await worker.process_ri4()
         logger.debug("[setup_hasl_sensor] Completed setting up RI4 sensors")
@@ -84,12 +84,12 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up SI2 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_DEVIATION:
-            if CONF_SI2_KEY in config.options:
-                for deviationid in ','.join(set(config.options[CONF_DEVIATION_LINES].split(','))).split(','):
-                    await worker.assert_si2_line(config.options[CONF_SI2_KEY], deviationid)
+            if CONF_SI2_KEY in config.data:
+                for deviationid in ','.join(set(config.data[CONF_DEVIATION_LINES].split(','))).split(','):
+                    await worker.assert_si2_line(config.data[CONF_SI2_KEY], deviationid)
                     sensors.append(HASLDeviationSensor(hass, config, CONF_DEVIATION_LINE, deviationid))
-                for deviationid in ','.join(set(config.options[CONF_DEVIATION_STOPS].split(','))).split(','):
-                    await worker.assert_si2_stop(config.options[CONF_SI2_KEY], deviationid)
+                for deviationid in ','.join(set(config.data[CONF_DEVIATION_STOPS].split(','))).split(','):
+                    await worker.assert_si2_stop(config.data[CONF_SI2_KEY], deviationid)
                     sensors.append(HASLDeviationSensor(hass, config, CONF_DEVIATION_STOP, deviationid))
             logger.debug("[setup_hasl_sensor] Force proccessing SI2 sensors")
             await worker.process_si2()
@@ -100,9 +100,9 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up RP3 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_ROUTE:
-            if CONF_RP3_KEY in config.options:
-                await worker.assert_rp3(config.options[CONF_RP3_KEY], config.options[CONF_SOURCE], config.options[CONF_DESTINATION])
-                sensors.append(HASLRouteSensor(hass, config, f"{config.options[CONF_SOURCE]}-{config.options[CONF_DESTINATION]}"))
+            if CONF_RP3_KEY in config.data:
+                await worker.assert_rp3(config.data[CONF_RP3_KEY], config.data[CONF_SOURCE], config.data[CONF_DESTINATION])
+                sensors.append(HASLRouteSensor(hass, config, f"{config.data[CONF_SOURCE]}-{config.data[CONF_DESTINATION]}"))
             logger.debug("[setup_hasl_sensor] Force proccessing RP3 sensors")
             await worker.process_rp3()
         logger.debug("[setup_hasl_sensor] Completed setting up RP3 sensors")
@@ -112,12 +112,12 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up TL2 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_STATUS:
-            if CONF_ANALOG_SENSORS in config.options:
-                if CONF_TL2_KEY in config.options:
-                    await worker.assert_tl2(config.options[CONF_TL2_KEY])
+            if CONF_ANALOG_SENSORS in config.data:
+                if CONF_TL2_KEY in config.data:
+                    await worker.assert_tl2(config.data[CONF_TL2_KEY])
 
                     for sensortype in CONF_TRANSPORT_MODE_LIST:
-                        if sensortype in config.options and config.options[sensortype]:
+                        if sensortype in config.data and config.data[sensortype]:
                             sensors.append(HASLTrafficStatusSensor(hass, config, sensortype))
 
                 logger.debug("[setup_hasl_sensor] Force proccessing TL2 sensors")
@@ -129,31 +129,31 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up FP sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_VEHICLE_LOCATION:
-            if CONF_FP_PT in config.options and config.options[CONF_FP_PT]:
+            if CONF_FP_PT in config.data and config.data[CONF_FP_PT]:
                 await worker.assert_fp("PT")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'PT'))
-            if CONF_FP_RB in config.options and config.options[CONF_FP_RB]:
+            if CONF_FP_RB in config.data and config.data[CONF_FP_RB]:
                 await worker.assert_fp("RB")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'RB'))
-            if CONF_FP_TVB in config.options and config.options[CONF_FP_TVB]:
+            if CONF_FP_TVB in config.data and config.data[CONF_FP_TVB]:
                 await worker.assert_fp("TVB")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'TVB'))
-            if CONF_FP_SB in config.options and config.options[CONF_FP_SB]:
+            if CONF_FP_SB in config.data and config.data[CONF_FP_SB]:
                 await worker.assert_fp("SB")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'SB'))
-            if CONF_FP_LB in config.options and config.options[CONF_FP_LB]:
+            if CONF_FP_LB in config.data and config.data[CONF_FP_LB]:
                 await worker.assert_fp("LB")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'LB'))
-            if CONF_FP_SPVC in config.options and config.options[CONF_FP_SPVC]:
+            if CONF_FP_SPVC in config.data and config.data[CONF_FP_SPVC]:
                 await worker.assert_fp("SpvC")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'SpvC'))
-            if CONF_FP_TB1 in config.options and config.options[CONF_FP_TB1]:
+            if CONF_FP_TB1 in config.data and config.data[CONF_FP_TB1]:
                 await worker.assert_fp("TB1")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'TB1'))
-            if CONF_FP_TB2 in config.options and config.options[CONF_FP_TB2]:
+            if CONF_FP_TB2 in config.data and config.data[CONF_FP_TB2]:
                 await worker.assert_fp("TB2")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'TB2'))
-            if CONF_FP_TB2 in config.options and config.options[CONF_FP_TB2]:
+            if CONF_FP_TB2 in config.data and config.data[CONF_FP_TB2]:
                 await worker.assert_fp("TB3")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'TB3'))
             logger.debug("[setup_hasl_sensor] Force proccessing FP sensors")
@@ -188,11 +188,11 @@ class HASLRouteSensor(HASLDevice):
         """Initialize."""
         self._hass = hass
         self._config = config
-        self._enabled_sensor = config.options[CONF_SENSOR]
+        self._enabled_sensor = config.data[CONF_SENSOR]
         self._trip = trip
         self._name = f"SL {self._trip} Route Sensor ({self._config.title})"
         self._sensordata = []
-        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -203,7 +203,7 @@ class HASLRouteSensor(HASLDevice):
 
         if self._worker.data.rp3[self._trip]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rp3[self._trip]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
+                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rp3[self._trip]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_rp3()
                         logger.debug("[async_update] Update processed")
@@ -316,19 +316,19 @@ class HASLDepartureSensor(HASLDevice):
 
         self._hass = hass
         self._config = config
-        self._lines = config.options[CONF_LINES]
+        self._lines = config.data[CONF_LINES]
         self._siteid = str(siteid)
         self._name = f"SL Departure Sensor {self._siteid} ({self._config.title})"
-        self._enabled_sensor = config.options[CONF_SENSOR]
-        self._sensorproperty = config.options[CONF_SENSOR_PROPERTY]
-        self._direction = config.options[CONF_DIRECTION]
-        self._timewindow = config.options[CONF_TIMEWINDOW]
+        self._enabled_sensor = config.data[CONF_SENSOR]
+        self._sensorproperty = config.data[CONF_SENSOR_PROPERTY]
+        self._direction = config.data[CONF_DIRECTION]
+        self._timewindow = config.data[CONF_TIMEWINDOW]
         self._nextdeparture_minutes = '0'
         self._nextdeparture_expected = '-'
         self._lastupdate = '-'
-        self._unit_of_measure = unit_table.get(self._config.options[CONF_SENSOR_PROPERTY], 'min')
+        self._unit_of_measure = unit_table.get(self._config.data[CONF_SENSOR_PROPERTY], 'min')
         self._sensordata = None
-        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
         if (self._lines==''):
@@ -343,7 +343,7 @@ class HASLDepartureSensor(HASLDevice):
         logger.debug(f"[async_update] Processing {self._name}")
         if self._worker.data.ri4[self._siteid]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.ri4[self._siteid]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
+                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.ri4[self._siteid]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_ri4()
                         logger.debug("[async_update] Update processed")
@@ -384,7 +384,7 @@ class HASLDepartureSensor(HASLDevice):
     @property
     def state(self):
         """Return the state of the sensor."""
-        sensorproperty = self._config.options[CONF_SENSOR_PROPERTY]
+        sensorproperty = self._config.data[CONF_SENSOR_PROPERTY]
 
         if self._sensordata == []:
             return 'Unknown'
@@ -519,11 +519,11 @@ class HASLDeviationSensor(HASLDevice):
         self._hass = hass
         self._deviationkey = deviationkey
         self._deviationtype = deviationtype
-        self._enabled_sensor = config.options[CONF_SENSOR]
+        self._enabled_sensor = config.data[CONF_SENSOR]
         self._name = f"SL {self._deviationtype.capitalize()} Deviation Sensor {self._deviationkey} ({self._config.title})"
         self._sensordata = []
         self._enabled_sensor
-        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -533,7 +533,7 @@ class HASLDeviationSensor(HASLDevice):
         logger.debug(f"[async_update] Processing {self._name}")
         if self._worker.data.si2[f"{self._deviationtype}_{self._deviationkey}"]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.si2[f"{self._deviationtype}_{self._deviationkey}"]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
+                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.si2[f"{self._deviationtype}_{self._deviationkey}"]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_si2()
                         logger.debug("[async_update] Update processed")
@@ -619,10 +619,10 @@ class HASLVehicleLocationSensor(HASLDevice):
         self._hass = hass
         self._config = config
         self._vehicletype = vehicletype
-        self._enabled_sensor = config.options[CONF_SENSOR]
+        self._enabled_sensor = config.data[CONF_SENSOR]
         self._name = f"SL {self._vehicletype} Location Sensor ({self._config.title})"
         self._sensordata = []
-        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -632,7 +632,7 @@ class HASLVehicleLocationSensor(HASLDevice):
         logger.debug(f"[async_update] Processing {self._name}")
         if self._worker.data.fp[self._vehicletype]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.fp[self._vehicletype]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
+                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.fp[self._vehicletype]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_fp()
                         logger.debug("[async_update] Update processed")
@@ -717,10 +717,10 @@ class HASLTrafficStatusSensor(HASLDevice):
         self._hass = hass
         self._config = config
         self._sensortype = sensortype
-        self._enabled_sensor = config.options[CONF_SENSOR]
+        self._enabled_sensor = config.data[CONF_SENSOR]
         self._name = f"SL {self._sensortype.capitalize()} Status Sensor ({self._config.title})"
         self._sensordata = []
-        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -728,9 +728,9 @@ class HASLTrafficStatusSensor(HASLDevice):
 
         logger.debug("[async_update] Entered")
         logger.debug(f"[async_update] Processing {self._name}")
-        if self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]["api_lastrun"]:
+        if self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
+                if self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_tl2()
                         logger.debug("[async_update] Update processed")
@@ -739,7 +739,7 @@ class HASLTrafficStatusSensor(HASLDevice):
                 else:
                     logger.debug("[async_update] Not due for update, skipping")
 
-        self._sensordata = self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]
+        self._sensordata = self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]
         logger.debug("[async_update] Completed")
         return
 

--- a/custom_components/hasl3/sensor.py
+++ b/custom_components/hasl3/sensor.py
@@ -112,7 +112,7 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up TL2 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_STATUS:
-            if config.options[CONF_ANALOG_SENSORS]:
+            if CONF_ANALOG_SENSORS in config.options:
                 if CONF_TL2_KEY in config.options:
                     await worker.assert_tl2(config.options[CONF_TL2_KEY])
 

--- a/custom_components/hasl3/sensor.py
+++ b/custom_components/hasl3/sensor.py
@@ -331,9 +331,10 @@ class HASLDepartureSensor(HASLDevice):
         self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
-
+        if (self._lines==''):
+            self._lines = []
         if (not isinstance(self._lines,list)):
-            self._lines = self._lines.split(',');
+            self._lines = self._lines.split(',')
 
     async def async_update(self):
         """Update the sensor."""

--- a/custom_components/hasl3/sensor.py
+++ b/custom_components/hasl3/sensor.py
@@ -250,6 +250,12 @@ class HASLRouteSensor(HASLDevice):
         return self._scan_interval
 
     @property
+    def available(self):
+        """Return true if value is valid."""
+        return self._sensordata != []
+
+
+    @property
     def extra_state_attributes(self):
 
         val = {}
@@ -454,6 +460,14 @@ class HASLDepartureSensor(HASLDevice):
         return self._scan_interval
 
     @property
+    def available(self):
+        """Return true if value is valid."""
+        if self._sensordata == [] or self._sensordata is None:
+            return False
+        else:
+            return True
+
+    @property
     def extra_state_attributes(self):
         """ Return the sensor attributes ."""
 
@@ -583,6 +597,11 @@ class HASLDeviationSensor(HASLDevice):
         return self._scan_interval
 
     @property
+    def available(self):
+        """Return true if value is valid."""
+        return self._sensordata != []
+
+    @property
     def extra_state_attributes(self):
         """ Return the sensor attributes."""
 
@@ -680,6 +699,11 @@ class HASLVehicleLocationSensor(HASLDevice):
     def scan_interval(self):
         """Return the unique id."""
         return self._scan_interval
+
+    @property
+    def available(self):
+        """Return true if value is valid."""
+        return self._sensordata != []
 
     @property
     def extra_state_attributes(self):
@@ -783,6 +807,14 @@ class HASLTrafficStatusSensor(HASLDevice):
     def scan_interval(self):
         """Return the unique id."""
         return self._scan_interval
+
+    @property
+    def available(self):
+        """Return true if value is valid."""
+        if not self._sensordata or not 'data' in self._sensordata:
+            return False
+        else:
+            return True
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/hasl3/slapi/const.py
+++ b/custom_components/hasl3/slapi/const.py
@@ -1,4 +1,4 @@
-__version__ = '3.0.4'
+__version__ = '3.0.5'
 VERSION = __version__
 
 FORDONSPOSITION_URL = 'https://api.sl.se/fordonspositioner/GetData?' \

--- a/custom_components/hasl3/slapi/const.py
+++ b/custom_components/hasl3/slapi/const.py
@@ -1,5 +1,4 @@
-__version__ = '3.0.5'
-VERSION = __version__
+from ..const import HASL_VERSION as __version__
 
 FORDONSPOSITION_URL = 'https://api.sl.se/fordonspositioner/GetData?' \
                       'type={}&pp=false&cacheControl={}'
@@ -16,4 +15,4 @@ RP3_URL = TRAFIKLAB_URL + 'TravelplannerV3_1/trip.json?key={}&originExtId={}' \
                           '&originCoordLong={}&destCoordLat={}' \
                           '&destCoordLong={}&Passlist=1'
 
-USER_AGENT = "hasl-slapi/" + VERSION
+USER_AGENT = "hasl-slapi/" + __version__

--- a/custom_components/hasl3/slapi/const.py
+++ b/custom_components/hasl3/slapi/const.py
@@ -1,4 +1,4 @@
-from ..const import HASL_VERSION as __version__
+__version__ = '3.0.5'
 
 FORDONSPOSITION_URL = 'https://api.sl.se/fordonspositioner/GetData?' \
                       'type={}&pp=false&cacheControl={}'

--- a/custom_components/hasl3/system_health.py
+++ b/custom_components/hasl3/system_health.py
@@ -8,7 +8,8 @@ from homeassistant.core import HomeAssistant, callback
 from .const import (
     DOMAIN,
     HASL_VERSION,
-    SLAPI_VERSION
+    SLAPI_VERSION,
+    SCHEMA_VERSION
 )
 
 logger = logging.getLogger(f"custom_components.{DOMAIN}.core")
@@ -58,6 +59,7 @@ async def system_health_info(hass):
         statusObject = {
             "Core Version": HASL_VERSION,
             "Slapi Version": SLAPI_VERSION,
+            "Schema Version": SCHEMA_VERSION,
             "Instances": worker.instances.count(),
             "Database Size": f"{get_size(worker.data)} bytes",
             "Startup in progress": worker.status.startup_in_progress,
@@ -70,6 +72,7 @@ async def system_health_info(hass):
         return {
             "Core Version": HASL_VERSION,
             "Slapi Version": SLAPI_VERSION,
+            "Schema Version": SCHEMA_VERSION,
             "Instances": "(worker_failed)",
             "Database Size": "(worker_failed)",
             "Startup in progress": "(worker_failed)",

--- a/custom_components/hasl3/system_health.py
+++ b/custom_components/hasl3/system_health.py
@@ -57,9 +57,8 @@ async def system_health_info(hass):
 
     try:
         statusObject = {
-            "Core Version": HASL_VERSION,
-            "Slapi Version": SLAPI_VERSION,
-            "Schema Version": SCHEMA_VERSION,
+            "Version": HASL_VERSION,
+            "Schema": SCHEMA_VERSION,
             "Instances": worker.instances.count(),
             "Database Size": f"{get_size(worker.data)} bytes",
             "Startup in progress": worker.status.startup_in_progress,
@@ -70,9 +69,8 @@ async def system_health_info(hass):
     except:
         logger.debug("[system_health_info] Information gather Failed")
         return {
-            "Core Version": HASL_VERSION,
-            "Slapi Version": SLAPI_VERSION,
-            "Schema Version": SCHEMA_VERSION,
+            "Version": HASL_VERSION,
+            "Schema": SCHEMA_VERSION,
             "Instances": "(worker_failed)",
             "Database Size": "(worker_failed)",
             "Startup in progress": "(worker_failed)",

--- a/custom_components/hasl3/system_health.py
+++ b/custom_components/hasl3/system_health.py
@@ -8,7 +8,6 @@ from homeassistant.core import HomeAssistant, callback
 from .const import (
     DOMAIN,
     HASL_VERSION,
-    SLAPI_VERSION,
     SCHEMA_VERSION
 )
 


### PR DESCRIPTION
### Fixes
- Fixes [hasl-sensor/integration#36](https://github.com/hasl-sensor/integration/issues/36) introduced in 3.0.3
- Fixes [hasl-sensor/integration#35](https://github.com/hasl-sensor/integration/issues/35) anoying log message due to stupidity

### Changes
- Sensor will now show unavailable until sensor data is initiated
- Configuration now stored in data and not options inside of configuration object
- Implemented separate configuration schema versioning (restarting with schema version 2. Everyting earlier is to be treated as version 1)
- Now configures integration in one step when adding new integration
- Harmonizing version settings between slapi and core as theese will never differ anymore