### PR TITLE
Align with Python 3.11 (asyncio.coroutine not found)

### DIFF
--- a/custom_components/hasl3/__init__.py
+++ b/custom_components/hasl3/__init__.py
@@ -38,7 +38,6 @@ logger = logging.getLogger(f"custom_components.{DOMAIN}.core")
 serviceLogger = logging.getLogger(f"custom_components.{DOMAIN}.services")
 
 
-@asyncio.coroutine
 async def async_setup(hass, config):
     """Set up HASL integration"""
     logger.debug("[setup] Entering")


### PR DESCRIPTION
align with python 3.11 #56