### PR TITLE
split config_entries data into `data` and `options` parts

### DIFF
--- a/custom_components/hasl3/config_flow.py
+++ b/custom_components/hasl3/config_flow.py
@@ -146,7 +146,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                     self._userdata.update(user_input)
 
-                    tempresult = self.async_create_entry(title=name, data=self._userdata)
+                    # split configuration into data and options
+                    data = {
+                        CONF_INTEGRATION_ID: self._userdata[CONF_INTEGRATION_ID],
+                        CONF_INTEGRATION_TYPE: self._userdata[CONF_INTEGRATION_TYPE],
+                    }
+                    options = {k: v for k, v in self._userdata.items() if k not in data}
+
+                    tempresult = self.async_create_entry(title=name, data=data, options=options)
                     logger.debug("[setup_integration_config] Entry creating succeeded")
                     return tempresult
                 except:
@@ -188,21 +195,21 @@ class OptionsFlow(config_entries.OptionsFlow):
         errors = {}
 
         if self.config_entry.data[CONF_INTEGRATION_TYPE] == SENSOR_STANDARD:
-            schema = standard_config_option_schema(self.config_entry.data)
+            schema = standard_config_option_schema(self.config_entry.options)
         if self.config_entry.data[CONF_INTEGRATION_TYPE] == SENSOR_STATUS:
-            schema = status_config_option_schema(self.config_entry.data)
+            schema = status_config_option_schema(self.config_entry.options)
         if self.config_entry.data[CONF_INTEGRATION_TYPE] == SENSOR_VEHICLE_LOCATION:
-            schema = vehiclelocation_config_option_schema(self.config_entry.data)
+            schema = vehiclelocation_config_option_schema(self.config_entry.options)
         if self.config_entry.data[CONF_INTEGRATION_TYPE] == SENSOR_DEVIATION:
-            schema = deviation_config_option_schema(self.config_entry.data)
+            schema = deviation_config_option_schema(self.config_entry.options)
         if self.config_entry.data[CONF_INTEGRATION_TYPE] == SENSOR_ROUTE:
-            schema = route_config_option_schema(self.config_entry.data)
+            schema = route_config_option_schema(self.config_entry.options)
         if self.config_entry.data[CONF_INTEGRATION_TYPE] == SENSOR_RRDEP:
-            schema = rrdep_config_option_schema(self.config_entry.data)         
+            schema = rrdep_config_option_schema(self.config_entry.options)
         if self.config_entry.data[CONF_INTEGRATION_TYPE] == SENSOR_RRARR:
-            schema = rrarr_config_option_schema(self.config_entry.data)         
+            schema = rrarr_config_option_schema(self.config_entry.options)
         if self.config_entry.data[CONF_INTEGRATION_TYPE] == SENSOR_RRROUTE:
-            schema = rrroute_config_option_schema(self.config_entry.data)         
+            schema = rrroute_config_option_schema(self.config_entry.options)
 
         logger.debug(f"[integration_options] Schema is {self.config_entry.data[CONF_INTEGRATION_TYPE]}")
 

--- a/custom_components/hasl3/const.py
+++ b/custom_components/hasl3/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import (
 )
 
 HASL_VERSION = "3.1.1"
-SCHEMA_VERSION = "3"
+SCHEMA_VERSION = "4"
 DOMAIN = "hasl3"
 NAME = "Swedish Public Transport Sensor (HASL)"
 

--- a/custom_components/hasl3/sensor.py
+++ b/custom_components/hasl3/sensor.py
@@ -78,9 +78,9 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up RI4 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_STANDARD:
-            if CONF_RI4_KEY in config.data and CONF_SITE_ID in config.data:
-                await worker.assert_ri4(config.data[CONF_RI4_KEY], config.data[CONF_SITE_ID])
-                sensors.append(HASLDepartureSensor(hass, config, config.data[CONF_SITE_ID]))
+            if CONF_RI4_KEY in config.options and CONF_SITE_ID in config.options:
+                await worker.assert_ri4(config.options[CONF_RI4_KEY], config.options[CONF_SITE_ID])
+                sensors.append(HASLDepartureSensor(hass, config, config.options[CONF_SITE_ID]))
             logger.debug("[setup_hasl_sensor] Force proccessing RI4 sensors")
             await worker.process_ri4()
         logger.debug("[setup_hasl_sensor] Completed setting up RI4 sensors")
@@ -90,12 +90,12 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up SI2 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_DEVIATION:
-            if CONF_SI2_KEY in config.data:
-                for deviationid in ','.join(set(config.data[CONF_DEVIATION_LINES].split(','))).split(','):
-                    await worker.assert_si2_line(config.data[CONF_SI2_KEY], deviationid)
+            if CONF_SI2_KEY in config.options:
+                for deviationid in ','.join(set(config.options[CONF_DEVIATION_LINES].split(','))).split(','):
+                    await worker.assert_si2_line(config.options[CONF_SI2_KEY], deviationid)
                     sensors.append(HASLDeviationSensor(hass, config, CONF_DEVIATION_LINE, deviationid))
-                for deviationid in ','.join(set(config.data[CONF_DEVIATION_STOPS].split(','))).split(','):
-                    await worker.assert_si2_stop(config.data[CONF_SI2_KEY], deviationid)
+                for deviationid in ','.join(set(config.options[CONF_DEVIATION_STOPS].split(','))).split(','):
+                    await worker.assert_si2_stop(config.options[CONF_SI2_KEY], deviationid)
                     sensors.append(HASLDeviationSensor(hass, config, CONF_DEVIATION_STOP, deviationid))
             logger.debug("[setup_hasl_sensor] Force proccessing SI2 sensors")
             await worker.process_si2()
@@ -106,9 +106,9 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up RP3 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_ROUTE:
-            if CONF_RP3_KEY in config.data:
-                await worker.assert_rp3(config.data[CONF_RP3_KEY], config.data[CONF_SOURCE], config.data[CONF_DESTINATION])
-                sensors.append(HASLRouteSensor(hass, config, f"{config.data[CONF_SOURCE]}-{config.data[CONF_DESTINATION]}"))
+            if CONF_RP3_KEY in config.options:
+                await worker.assert_rp3(config.options[CONF_RP3_KEY], config.options[CONF_SOURCE], config.options[CONF_DESTINATION])
+                sensors.append(HASLRouteSensor(hass, config, f"{config.options[CONF_SOURCE]}-{config.options[CONF_DESTINATION]}"))
             logger.debug("[setup_hasl_sensor] Force proccessing RP3 sensors")
             await worker.process_rp3()
         logger.debug("[setup_hasl_sensor] Completed setting up RP3 sensors")
@@ -118,12 +118,12 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up TL2 sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_STATUS:
-            if CONF_ANALOG_SENSORS in config.data:
-                if CONF_TL2_KEY in config.data:
-                    await worker.assert_tl2(config.data[CONF_TL2_KEY])
+            if CONF_ANALOG_SENSORS in config.options:
+                if CONF_TL2_KEY in config.options:
+                    await worker.assert_tl2(config.options[CONF_TL2_KEY])
 
                     for sensortype in CONF_TRANSPORT_MODE_LIST:
-                        if sensortype in config.data and config.data[sensortype]:
+                        if sensortype in config.options and config.options[sensortype]:
                             sensors.append(HASLTrafficStatusSensor(hass, config, sensortype))
 
                 logger.debug("[setup_hasl_sensor] Force proccessing TL2 sensors")
@@ -135,31 +135,31 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up FP sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_VEHICLE_LOCATION:
-            if CONF_FP_PT in config.data and config.data[CONF_FP_PT]:
+            if CONF_FP_PT in config.options and config.options[CONF_FP_PT]:
                 await worker.assert_fp("PT")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'PT'))
-            if CONF_FP_RB in config.data and config.data[CONF_FP_RB]:
+            if CONF_FP_RB in config.options and config.options[CONF_FP_RB]:
                 await worker.assert_fp("RB")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'RB'))
-            if CONF_FP_TVB in config.data and config.data[CONF_FP_TVB]:
+            if CONF_FP_TVB in config.options and config.options[CONF_FP_TVB]:
                 await worker.assert_fp("TVB")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'TVB'))
-            if CONF_FP_SB in config.data and config.data[CONF_FP_SB]:
+            if CONF_FP_SB in config.options and config.options[CONF_FP_SB]:
                 await worker.assert_fp("SB")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'SB'))
-            if CONF_FP_LB in config.data and config.data[CONF_FP_LB]:
+            if CONF_FP_LB in config.options and config.options[CONF_FP_LB]:
                 await worker.assert_fp("LB")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'LB'))
-            if CONF_FP_SPVC in config.data and config.data[CONF_FP_SPVC]:
+            if CONF_FP_SPVC in config.options and config.options[CONF_FP_SPVC]:
                 await worker.assert_fp("SpvC")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'SpvC'))
-            if CONF_FP_TB1 in config.data and config.data[CONF_FP_TB1]:
+            if CONF_FP_TB1 in config.options and config.options[CONF_FP_TB1]:
                 await worker.assert_fp("TB1")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'TB1'))
-            if CONF_FP_TB2 in config.data and config.data[CONF_FP_TB2]:
+            if CONF_FP_TB2 in config.options and config.options[CONF_FP_TB2]:
                 await worker.assert_fp("TB2")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'TB2'))
-            if CONF_FP_TB2 in config.data and config.data[CONF_FP_TB2]:
+            if CONF_FP_TB2 in config.options and config.options[CONF_FP_TB2]:
                 await worker.assert_fp("TB3")
                 sensors.append(HASLVehicleLocationSensor(hass, config, 'TB3'))
             logger.debug("[setup_hasl_sensor] Force proccessing FP sensors")
@@ -171,9 +171,9 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up RRD sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_RRDEP:
-            if CONF_RR_KEY in config.data and CONF_SITE_ID in config.data:
-                await worker.assert_rrd(config.data[CONF_RR_KEY], config.data[CONF_SITE_ID])
-                sensors.append(HASLRRDepartureSensor(hass, config, config.data[CONF_SITE_ID]))
+            if CONF_RR_KEY in config.options and CONF_SITE_ID in config.options:
+                await worker.assert_rrd(config.options[CONF_RR_KEY], config.options[CONF_SITE_ID])
+                sensors.append(HASLRRDepartureSensor(hass, config, config.options[CONF_SITE_ID]))
             logger.debug("[setup_hasl_sensor] Force proccessing RRD sensors")
             await worker.process_rrd()
         logger.debug("[setup_hasl_sensor] Completed setting up RRD sensors")
@@ -183,9 +183,9 @@ async def setup_hasl_sensor(hass, config):
     try:
         logger.debug("[setup_hasl_sensor] Setting up RRA sensors..")
         if config.data[CONF_INTEGRATION_TYPE] == SENSOR_RRARR:
-            if CONF_RR_KEY in config.data and CONF_SITE_ID in config.data:
-                await worker.assert_rra(config.data[CONF_RR_KEY], config.data[CONF_SITE_ID])
-                sensors.append(HASLRRArrivalSensor(hass, config, config.data[CONF_SITE_ID]))
+            if CONF_RR_KEY in config.options and CONF_SITE_ID in config.options:
+                await worker.assert_rra(config.options[CONF_RR_KEY], config.options[CONF_SITE_ID])
+                sensors.append(HASLRRArrivalSensor(hass, config, config.options[CONF_SITE_ID]))
             logger.debug("[setup_hasl_sensor] Force proccessing RRA sensors")
             await worker.process_rra()
         logger.debug("[setup_hasl_sensor] Completed setting up RRA sensors")
@@ -195,9 +195,9 @@ async def setup_hasl_sensor(hass, config):
     #try:
     logger.debug("[setup_hasl_sensor] Setting up RRR sensors..")
     if config.data[CONF_INTEGRATION_TYPE] == SENSOR_RRROUTE:
-        if CONF_RR_KEY in config.data:
-            await worker.assert_rrr(config.data[CONF_RR_KEY], config.data[CONF_SOURCE_ID], config.data[CONF_DESTINATION_ID])
-            sensors.append(HASLRRRouteSensor(hass, config, f"{config.data[CONF_SOURCE_ID]}-{config.data[CONF_DESTINATION_ID]}"))
+        if CONF_RR_KEY in config.options:
+            await worker.assert_rrr(config.options[CONF_RR_KEY], config.options[CONF_SOURCE_ID], config.options[CONF_DESTINATION_ID])
+            sensors.append(HASLRRRouteSensor(hass, config, f"{config.options[CONF_SOURCE_ID]}-{config.options[CONF_DESTINATION_ID]}"))
         logger.debug("[setup_hasl_sensor] Force proccessing RRR sensors")
         await worker.process_rrr()
     logger.debug("[setup_hasl_sensor] Completed setting up RRR sensors")
@@ -230,11 +230,11 @@ class HASLRouteSensor(HASLDevice):
         """Initialize."""
         self._hass = hass
         self._config = config
-        self._enabled_sensor = config.data[CONF_SENSOR]
+        self._enabled_sensor = config.options[CONF_SENSOR]
         self._trip = trip
         self._name = f"SL {self._trip} Route Sensor ({self._config.title})"
         self._sensordata = []
-        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -245,7 +245,7 @@ class HASLRouteSensor(HASLDevice):
 
         if self._worker.data.rp3[self._trip]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rp3[self._trip]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
+                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rp3[self._trip]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_rp3()
                         logger.debug("[async_update] Update processed")
@@ -355,11 +355,11 @@ class HASLRRRouteSensor(HASLDevice):
         """Initialize."""
         self._hass = hass
         self._config = config
-        self._enabled_sensor = config.data[CONF_SENSOR]
+        self._enabled_sensor = config.options[CONF_SENSOR]
         self._trip = trip
         self._name = f"RR {self._trip} Route Sensor ({self._config.title})"
         self._sensordata = []
-        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -370,7 +370,7 @@ class HASLRRRouteSensor(HASLDevice):
 
         if self._worker.data.rrr[self._trip]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rrr[self._trip]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
+                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rrr[self._trip]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_rrr()
                         logger.debug("[async_update] Update processed")
@@ -489,19 +489,19 @@ class HASLDepartureSensor(HASLDevice):
 
         self._hass = hass
         self._config = config
-        self._lines = config.data[CONF_LINES]
+        self._lines = config.options[CONF_LINES]
         self._siteid = str(siteid)
         self._name = f"SL Departure Sensor {self._siteid} ({self._config.title})"
-        self._enabled_sensor = config.data[CONF_SENSOR]
-        self._sensorproperty = config.data[CONF_SENSOR_PROPERTY]
-        self._direction = config.data[CONF_DIRECTION]
-        self._timewindow = config.data[CONF_TIMEWINDOW]
+        self._enabled_sensor = config.options[CONF_SENSOR]
+        self._sensorproperty = config.options[CONF_SENSOR_PROPERTY]
+        self._direction = config.options[CONF_DIRECTION]
+        self._timewindow = config.options[CONF_TIMEWINDOW]
         self._nextdeparture_minutes = '0'
         self._nextdeparture_expected = '-'
         self._lastupdate = '-'
-        self._unit_of_measure = unit_table.get(self._config.data[CONF_SENSOR_PROPERTY], 'min')
+        self._unit_of_measure = unit_table.get(self._config.options[CONF_SENSOR_PROPERTY], 'min')
         self._sensordata = None
-        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
         if (self._lines==''):
@@ -516,7 +516,7 @@ class HASLDepartureSensor(HASLDevice):
         logger.debug(f"[async_update] Processing {self._name}")
         if self._worker.data.ri4[self._siteid]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.ri4[self._siteid]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
+                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.ri4[self._siteid]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_ri4()
                         logger.debug("[async_update] Update processed")
@@ -557,7 +557,7 @@ class HASLDepartureSensor(HASLDevice):
     @property
     def state(self):
         """Return the state of the sensor."""
-        sensorproperty = self._config.data[CONF_SENSOR_PROPERTY]
+        sensorproperty = self._config.options[CONF_SENSOR_PROPERTY]
 
         if self._sensordata == []:
             return 'Unknown'
@@ -704,19 +704,19 @@ class HASLRRDepartureSensor(HASLDevice):
 
         self._hass = hass
         self._config = config
-        self._lines = config.data[CONF_LINES]
+        self._lines = config.options[CONF_LINES]
         self._siteid = str(siteid)
         self._name = f"RR Departure Sensor {self._siteid} ({self._config.title})"
-        self._enabled_sensor = config.data[CONF_SENSOR]
-        self._sensorproperty = config.data[CONF_SENSOR_PROPERTY]
-        self._direction = config.data[CONF_DIRECTION]
-        self._timewindow = config.data[CONF_TIMEWINDOW]
+        self._enabled_sensor = config.options[CONF_SENSOR]
+        self._sensorproperty = config.options[CONF_SENSOR_PROPERTY]
+        self._direction = config.options[CONF_DIRECTION]
+        self._timewindow = config.options[CONF_TIMEWINDOW]
         self._nextdeparture_minutes = '0'
         self._nextdeparture_expected = '-'
         self._lastupdate = '-'
-        self._unit_of_measure = unit_table.get(self._config.data[CONF_SENSOR_PROPERTY], 'min')
+        self._unit_of_measure = unit_table.get(self._config.options[CONF_SENSOR_PROPERTY], 'min')
         self._sensordata = None
-        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
         if (self._lines==''):
@@ -731,7 +731,7 @@ class HASLRRDepartureSensor(HASLDevice):
         logger.debug(f"[async_update] Processing {self._name}")
         if self._worker.data.rrd[self._siteid]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rrd[self._siteid]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
+                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rrd[self._siteid]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_rrd()
                         logger.debug("[async_update] Update processed")
@@ -758,7 +758,7 @@ class HASLRRDepartureSensor(HASLDevice):
     @property
     def state(self):
         """Return the state of the sensor."""
-        sensorproperty = self._config.data[CONF_SENSOR_PROPERTY]
+        sensorproperty = self._config.options[CONF_SENSOR_PROPERTY]
 
         if self._sensordata == []:
             return 'Unknown'
@@ -888,7 +888,7 @@ class HASLRRDepartureSensor(HASLDevice):
             val['error'] = "NoDataYet"
             logger.debug(f"Data was not avaliable for processing when getting attributes for sensor {self._name}")
 
-        return val        
+        return val
 
 class HASLRRArrivalSensor(HASLDevice):
     """HASL Arrival Sensor class."""
@@ -904,19 +904,19 @@ class HASLRRArrivalSensor(HASLDevice):
 
         self._hass = hass
         self._config = config
-        self._lines = config.data[CONF_LINES]
+        self._lines = config.options[CONF_LINES]
         self._siteid = str(siteid)
         self._name = f"RR Arrival Sensor {self._siteid} ({self._config.title})"
-        self._enabled_sensor = config.data[CONF_SENSOR]
-        self._sensorproperty = config.data[CONF_SENSOR_PROPERTY]
-        self._direction = config.data[CONF_DIRECTION]
-        self._timewindow = config.data[CONF_TIMEWINDOW]
+        self._enabled_sensor = config.options[CONF_SENSOR]
+        self._sensorproperty = config.options[CONF_SENSOR_PROPERTY]
+        self._direction = config.options[CONF_DIRECTION]
+        self._timewindow = config.options[CONF_TIMEWINDOW]
         self._nextarrival_minutes = '0'
         self._nextarrival_expected = '-'
         self._lastupdate = '-'
-        self._unit_of_measure = unit_table.get(self._config.data[CONF_SENSOR_PROPERTY], 'min')
+        self._unit_of_measure = unit_table.get(self._config.options[CONF_SENSOR_PROPERTY], 'min')
         self._sensordata = None
-        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
         if (self._lines==''):
@@ -931,7 +931,7 @@ class HASLRRArrivalSensor(HASLDevice):
         logger.debug(f"[async_update] Processing {self._name}")
         if self._worker.data.rrd[self._siteid]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rra[self._siteid]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
+                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.rra[self._siteid]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_rra()
                         logger.debug("[async_update] Update processed")
@@ -957,7 +957,7 @@ class HASLRRArrivalSensor(HASLDevice):
     @property
     def state(self):
         """Return the state of the sensor."""
-        sensorproperty = self._config.data[CONF_SENSOR_PROPERTY]
+        sensorproperty = self._config.options[CONF_SENSOR_PROPERTY]
 
         if self._sensordata == []:
             return 'Unknown'
@@ -1090,7 +1090,7 @@ class HASLRRArrivalSensor(HASLDevice):
             val['error'] = "NoDataYet"
             logger.debug(f"Data was not avaliable for processing when getting attributes for sensor {self._name}")
 
-        return val        
+        return val
 
 
 
@@ -1103,11 +1103,11 @@ class HASLDeviationSensor(HASLDevice):
         self._hass = hass
         self._deviationkey = deviationkey
         self._deviationtype = deviationtype
-        self._enabled_sensor = config.data[CONF_SENSOR]
+        self._enabled_sensor = config.options[CONF_SENSOR]
         self._name = f"SL {self._deviationtype.capitalize()} Deviation Sensor {self._deviationkey} ({self._config.title})"
         self._sensordata = []
         self._enabled_sensor
-        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -1117,7 +1117,7 @@ class HASLDeviationSensor(HASLDevice):
         logger.debug(f"[async_update] Processing {self._name}")
         if self._worker.data.si2[f"{self._deviationtype}_{self._deviationkey}"]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.si2[f"{self._deviationtype}_{self._deviationkey}"]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
+                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.si2[f"{self._deviationtype}_{self._deviationkey}"]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_si2()
                         logger.debug("[async_update] Update processed")
@@ -1208,10 +1208,10 @@ class HASLVehicleLocationSensor(HASLDevice):
         self._hass = hass
         self._config = config
         self._vehicletype = vehicletype
-        self._enabled_sensor = config.data[CONF_SENSOR]
+        self._enabled_sensor = config.options[CONF_SENSOR]
         self._name = f"SL {self._vehicletype} Location Sensor ({self._config.title})"
         self._sensordata = []
-        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -1221,7 +1221,7 @@ class HASLVehicleLocationSensor(HASLDevice):
         logger.debug(f"[async_update] Processing {self._name}")
         if self._worker.data.fp[self._vehicletype]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.fp[self._vehicletype]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
+                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.fp[self._vehicletype]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_fp()
                         logger.debug("[async_update] Update processed")
@@ -1311,10 +1311,10 @@ class HASLTrafficStatusSensor(HASLDevice):
         self._hass = hass
         self._config = config
         self._sensortype = sensortype
-        self._enabled_sensor = config.data[CONF_SENSOR]
+        self._enabled_sensor = config.options[CONF_SENSOR]
         self._name = f"SL {self._sensortype.capitalize()} Status Sensor ({self._config.title})"
         self._sensordata = []
-        self._scan_interval = self._config.data[CONF_SCAN_INTERVAL] or 300
+        self._scan_interval = self._config.options[CONF_SCAN_INTERVAL] or 300
         self._worker = hass.data[DOMAIN]["worker"]
 
     async def async_update(self):
@@ -1322,9 +1322,9 @@ class HASLTrafficStatusSensor(HASLDevice):
 
         logger.debug("[async_update] Entered")
         logger.debug(f"[async_update] Processing {self._name}")
-        if self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]["api_lastrun"]:
+        if self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]["api_lastrun"]:
             if self._worker.checksensorstate(self._enabled_sensor, STATE_ON):
-                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]["api_lastrun"]) > self._config.data[CONF_SCAN_INTERVAL]:
+                if self._sensordata == [] or self._worker.getminutesdiff(now().strftime('%Y-%m-%d %H:%M:%S'), self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]["api_lastrun"]) > self._config.options[CONF_SCAN_INTERVAL]:
                     try:
                         await self._worker.process_tl2()
                         logger.debug("[async_update] Update processed")
@@ -1333,7 +1333,7 @@ class HASLTrafficStatusSensor(HASLDevice):
                 else:
                     logger.debug("[async_update] Not due for update, skipping")
 
-        self._sensordata = self._worker.data.tl2[self._config.data[CONF_TL2_KEY]]
+        self._sensordata = self._worker.data.tl2[self._config.options[CONF_TL2_KEY]]
         logger.debug("[async_update] Completed")
         return
 


### PR DESCRIPTION
This allows changing all parameters other than integration type and
it's id at any point

This change also contains a bump to `SCHEMA_VERSION` up to 4 and a migration steps for existing configurations of version 3


I've only checked this with "SL Departure" integration, so additional testing is much appreciated :)  