### PR TITLE
Fix config entry version migration

### DIFF
--- a/custom_components/hasl3/__init__.py
+++ b/custom_components/hasl3/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_SITE_ID,
     DEVICE_GUID,
     DOMAIN,
+    SCHEMA_MINOR_VERSION,
     SCHEMA_VERSION,
     SENSOR_DEPARTURE,
     SENSOR_ROUTE,
@@ -69,6 +70,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigEntry):
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Migrate HASL config entries."""
+    hass.config_entries.async_update_entry(
+        config_entry,
+        version=SCHEMA_VERSION,
+        minor_version=SCHEMA_MINOR_VERSION,
+    )
     return True
 
 

--- a/custom_components/hasl3/config_flow.py
+++ b/custom_components/hasl3/config_flow.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_SITE_ID,
     CONF_SOURCE,
     DOMAIN,
+    SCHEMA_MINOR_VERSION,
     SCHEMA_VERSION,
     SENSOR_DEPARTURE,
     SENSOR_RESROBOT_ARRIVAL,
@@ -49,6 +50,24 @@ from .rrapi.model import LocationSearchType
 from .utils import DestinationInvalid, SourceInvalid, siteid_or_coords
 
 logger = logging.getLogger(__name__)
+
+
+class ConfigEntryVersion(int):
+    """Config entry version that can compare against legacy string versions."""
+
+    @staticmethod
+    def _version_as_int(value: object) -> int:
+        if isinstance(value, int):
+            return value
+        return int(value)  # type: ignore[arg-type]
+
+    def __eq__(self, other: object) -> bool:
+        return int(self) == self._version_as_int(other)
+
+    def __lt__(self, other: object) -> bool:
+        return int(self) < self._version_as_int(other)
+
+    __hash__ = int.__hash__
 
 
 async def get_schema_by_handler(handler: SchemaCommonFlowHandler):
@@ -146,7 +165,8 @@ class LocationLookupMixin:
 class ConfigFlowHandler(ConfigFlow, LocationLookupMixin, domain=DOMAIN):
     """Handle a config flow for HASL."""
 
-    VERSION = SCHEMA_VERSION
+    VERSION = ConfigEntryVersion(SCHEMA_VERSION)
+    MINOR_VERSION = SCHEMA_MINOR_VERSION
     CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
 
     new_sensors = [

--- a/custom_components/hasl3/const.py
+++ b/custom_components/hasl3/const.py
@@ -4,6 +4,7 @@ from enum import IntEnum
 
 HASL_VERSION = "4.0.0"
 SCHEMA_VERSION = 5
+SCHEMA_MINOR_VERSION = 2
 DOMAIN = "hasl3"
 NAME = "Swedish Public Transport Sensor (HASL)"
 


### PR DESCRIPTION
## What changed

Fixes #93.

This fixes startup on Home Assistant 2026.7 when an existing HASL config entry has its version stored as a string, for example "5" instead of 5.

Home Assistant now compares the stored config entry version with the flow handler version before calling the integration migration hook. If the stored value is a string, that comparison raises a TypeError and the integration never gets a chance to clean it up.

The patch does two things:

- lets config flow version compare with legacy numeric strings
- bumps the minor config entry version so entries already at "5" (or less) still run the migration and get saved as integer versions

## Tested

- python3 -m py_compile custom_components/hasl3/config_flow.py custom_components/hasl3/__init__.py custom_components/hasl3/const.py
- Tested manually on a Home Assistant instance that was hitting the startup error. Sample of one.
- Verified the affected config entries were rewritten to numeric version 5 and minor_version 2
